### PR TITLE
Changed port to 31371 as 8080 doesn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ mvn fabric8:build fabric8:resource fabric8:deploy
 
 ```curl
 curl -X GET \
-  http://127.0.0.1:8080/api/pets \
+  http://127.0.0.1:31371/api/pets \
   -H 'Accept: application/json' \
   -H 'Content-Type: application/json'
    


### PR DESCRIPTION
Hi, the curl example doesn't work on port 8080, so I changed it to 31371. This is probably due to fabricb/svc.yaml where the nodePort is 31371